### PR TITLE
[codex] Fix WeChat minigame loading and iOS display handling

### DIFF
--- a/skills/assets/min-runtime/godot-loader.js
+++ b/skills/assets/min-runtime/godot-loader.js
@@ -37,14 +37,35 @@
 
         getDevicePixelRatio() {
             const info = this.getWindowInfo();
-            const ratio =
+            const ratio = Math.max(
+                1,
                 Number(info && (info.pixelRatio || info.devicePixelRatio)) ||
+                Number(gameGlobal.__godotMinigamePixelRatio) ||
                 Number(windowObject.devicePixelRatio) ||
-                1;
+                1
+            );
 
-            windowObject.devicePixelRatio = ratio;
             gameGlobal.__godotMinigamePixelRatio = ratio;
-            return Math.max(1, ratio);
+            this.syncWindowDevicePixelRatio(ratio);
+            return ratio;
+        }
+
+        syncWindowDevicePixelRatio(ratio) {
+            try {
+                const descriptor = Object.getOwnPropertyDescriptor(windowObject, "devicePixelRatio");
+                if (!descriptor || descriptor.configurable) {
+                    Object.defineProperty(windowObject, "devicePixelRatio", {
+                        configurable: true,
+                        get: () => gameGlobal.__godotMinigamePixelRatio || ratio,
+                    });
+                } else if (descriptor.writable || descriptor.set) {
+                    windowObject.devicePixelRatio = ratio;
+                }
+            } catch (err) {
+                try {
+                    windowObject.devicePixelRatio = ratio;
+                } catch (assignErr) {}
+            }
         }
 
         getViewportSize() {
@@ -158,18 +179,46 @@
             return program;
         }
 
-        loadImages() {
-            if (this.config.materialConfig.backgroundImage) {
-                this.backgroundImage = new Image();
-                this.backgroundImage.src = this.config.materialConfig.backgroundImage;
-                this.backgroundImage.onload = this.render.bind(this);
+        imageSourceFallbacks(src) {
+            if (!src || /^(https?:|data:|wxfile:|file:)/.test(src)) {
+                return src ? [src] : [];
             }
 
-            if (this.config.materialConfig.iconImage) {
-                this.iconImage = new Image();
-                this.iconImage.src = this.config.materialConfig.iconImage;
-                this.iconImage.onload = this.render.bind(this);
+            const relative = src.charAt(0) === "/" ? src.slice(1) : src;
+            return [relative, "/" + relative].filter((item, index, list) => item && list.indexOf(item) === index);
+        }
+
+        loadImage(src, label, assign) {
+            const sources = this.imageSourceFallbacks(src);
+            if (!sources.length) {
+                return;
             }
+
+            const image = new Image();
+            let index = 0;
+            image.onload = () => {
+                assign(image);
+                this.render();
+            };
+            image.onerror = (event) => {
+                if (index + 1 < sources.length) {
+                    index += 1;
+                    image.src = sources[index];
+                    return;
+                }
+                console.warn("[godot-loader] image load failed", label, image.src, event && (event.errMsg || event.message || event));
+            };
+            image.src = sources[index];
+        }
+
+        loadImages() {
+            const materialConfig = this.config.materialConfig || {};
+            this.loadImage(materialConfig.backgroundImage, "background", (image) => {
+                this.backgroundImage = image;
+            });
+            this.loadImage(materialConfig.iconImage, "icon", (image) => {
+                this.iconImage = image;
+            });
         }
 
         resizeCanvases() {

--- a/skills/assets/min-runtime/godot-loader.js
+++ b/skills/assets/min-runtime/godot-loader.js
@@ -29,15 +29,22 @@
             if (wxApi && typeof wxApi.getWindowInfo === "function") {
                 return wxApi.getWindowInfo();
             }
+            if (wxApi && typeof wxApi.getSystemInfoSync === "function") {
+                return wxApi.getSystemInfoSync();
+            }
             return null;
         }
 
         getDevicePixelRatio() {
             const info = this.getWindowInfo();
-            if (info && info.pixelRatio) {
-                return info.pixelRatio;
-            }
-            return windowObject.devicePixelRatio || 1;
+            const ratio =
+                Number(info && (info.pixelRatio || info.devicePixelRatio)) ||
+                Number(windowObject.devicePixelRatio) ||
+                1;
+
+            windowObject.devicePixelRatio = ratio;
+            gameGlobal.__godotMinigamePixelRatio = ratio;
+            return Math.max(1, ratio);
         }
 
         getViewportSize() {
@@ -202,6 +209,18 @@
             ctx.fill();
         }
 
+        drawCoverImage(ctx, image, width, height) {
+            if (!image.width || !image.height) {
+                ctx.drawImage(image, 0, 0, width, height);
+                return;
+            }
+
+            const scale = Math.max(width / image.width, height / image.height);
+            const drawWidth = image.width * scale;
+            const drawHeight = image.height * scale;
+            ctx.drawImage(image, (width - drawWidth) / 2, (height - drawHeight) / 2, drawWidth, drawHeight);
+        }
+
         render() {
             if (!this.gl) {
                 return;
@@ -216,7 +235,7 @@
             ctx.imageSmoothingQuality = "high";
 
             if (this.backgroundImage) {
-                ctx.drawImage(this.backgroundImage, 0, 0, width, height);
+                this.drawCoverImage(ctx, this.backgroundImage, width, height);
             }
 
             const barConfig = this.config.barConfig.style;
@@ -297,14 +316,31 @@
             this.gl.vertexAttribPointer(this.texCoordLocation, 2, this.gl.FLOAT, false, 0, 0);
 
             this.gl.drawArrays(this.gl.TRIANGLE_STRIP, 0, 4);
+
+            if (typeof this.gl.flush === "function") {
+                this.gl.flush();
+            }
+            if (typeof this.gl.commit === "function") {
+                this.gl.commit();
+            }
+        }
+
+        normalizeProgress(progress) {
+            const value = Number(progress) || 0;
+            return Math.max(0, Math.min(1, value > 1 ? value / 100 : value));
         }
 
         updateProgress(progress, text) {
-            this.progress = progress;
+            const normalized = this.normalizeProgress(progress);
+            this.progress = Math.max(this.progress || 0, normalized);
             if (text) {
                 this.currentText = text;
             }
             this.render();
+
+            if (typeof windowObject.requestAnimationFrame === "function") {
+                windowObject.requestAnimationFrame(() => this.render());
+            }
         }
 
         loadGameEngine() {
@@ -322,8 +358,7 @@
 
             if (task && typeof task.onProgressUpdate === "function") {
                 task.onProgressUpdate(({ progress }) => {
-                    this.progress = progress / 100;
-                    this.updateProgress(this.progress, this.config.textConfig.downloadingText[0]);
+                    this.updateProgress(progress, this.config.textConfig.downloadingText[0]);
                 });
             }
         }

--- a/skills/references/runtime-shell.md
+++ b/skills/references/runtime-shell.md
@@ -24,6 +24,8 @@ The bundled public adapter depends on only these pieces from the old SDK contrac
   - `getGodotPath`
 - `GameGlobal.nowPolyfill`
   - required by the bundled `godot_process.js` patching step
+- `window.devicePixelRatio`
+  - synchronized from `wx.getWindowInfo().pixelRatio` when available so generated Godot display code renders sharply on iOS high-DPI devices
 
 Keep these compatibility entries even though the current Godot-side runtime does not call them directly:
 
@@ -55,6 +57,13 @@ The minimal runtime intentionally preserves:
 - `GODOTSDK.copy_to_fs`
 - `GODOTSDK.load_pack`
 - `WXWebAssembly -> WebAssembly` override
+
+## What The Minimal `godot-loader.js` Handles
+
+- Uses `wx.getWindowInfo().pixelRatio` or `devicePixelRatio` for high-DPI loading output
+- Draws the loading background with cover behavior instead of stretching it
+- Normalizes subpackage progress whether WeChat reports `0..100` or `0..1`
+- Flushes and commits the WebGL loading frame when the runtime exposes explicit swap control
 
 ## What Was Deliberately Removed
 

--- a/skills/references/runtime-shell.md
+++ b/skills/references/runtime-shell.md
@@ -24,8 +24,9 @@ The bundled public adapter depends on only these pieces from the old SDK contrac
   - `getGodotPath`
 - `GameGlobal.nowPolyfill`
   - required by the bundled `godot_process.js` patching step
-- `window.devicePixelRatio`
-  - synchronized from `wx.getWindowInfo().pixelRatio` when available so generated Godot display code renders sharply on iOS high-DPI devices
+- `GameGlobal.__godotMinigamePixelRatio`
+  - synchronized from `wx.getWindowInfo().pixelRatio` when available so the loader and generated Godot display code render sharply on iOS high-DPI devices
+  - `godot-loader.js` installs a `window.devicePixelRatio` getter only when the host property is configurable, and otherwise avoids assigning to read-only runtime properties
 
 Keep these compatibility entries even though the current Godot-side runtime does not call them directly:
 
@@ -60,7 +61,8 @@ The minimal runtime intentionally preserves:
 
 ## What The Minimal `godot-loader.js` Handles
 
-- Uses `wx.getWindowInfo().pixelRatio` or `devicePixelRatio` for high-DPI loading output
+- Uses `wx.getWindowInfo().pixelRatio`, `GameGlobal.__godotMinigamePixelRatio`, or `devicePixelRatio` for high-DPI loading output
+- Loads images after installing `onload`/`onerror` handlers and retries relative/absolute local paths
 - Draws the loading background with cover behavior instead of stretching it
 - Normalizes subpackage progress whether WeChat reports `0..100` or `0..1`
 - Flushes and commits the WebGL loading frame when the runtime exposes explicit swap control

--- a/skills/references/validation-checklist.md
+++ b/skills/references/validation-checklist.md
@@ -123,6 +123,7 @@ Check:
 
 - sharp output on high-DPI screens
 - iOS high performance mode reports a real `pixelRatio` through `wx.getWindowInfo()`
+- startup does not warn about assigning to read-only `window.devicePixelRatio`
 - correct fullscreen/window sizing
 - keyboard type/replace/confirm/dismiss behavior
 

--- a/skills/references/validation-checklist.md
+++ b/skills/references/validation-checklist.md
@@ -122,6 +122,7 @@ Expected:
 Check:
 
 - sharp output on high-DPI screens
+- iOS high performance mode reports a real `pixelRatio` through `wx.getWindowInfo()`
 - correct fullscreen/window sizing
 - keyboard type/replace/confirm/dismiss behavior
 

--- a/skills/scripts/godot_process.js
+++ b/skills/scripts/godot_process.js
@@ -29,7 +29,7 @@ const PERFORMANCE_TIME_TEMPLATE = {
 }
 const DISPLAY_PIXEL_RATIO_TEMPLATE = {
     match: `getPixelRatio:function(){return GodotDisplayScreen.hidpi?window.devicePixelRatio||1:1}`,
-    replace: `getPixelRatio:function(){if(!GodotDisplayScreen.hidpi){return 1}let ratio=Number(window.devicePixelRatio)||1;try{if(typeof wx!=="undefined"){const info=wx.getWindowInfo?wx.getWindowInfo():wx.getSystemInfoSync&&wx.getSystemInfoSync();if(info){ratio=Number(info.pixelRatio||info.devicePixelRatio||ratio)||ratio}}}catch(e){}return Math.max(1,ratio)}`
+    replace: `getPixelRatio:function(){if(!GodotDisplayScreen.hidpi){return 1}let ratio=Number((typeof GameGlobal!=="undefined"&&GameGlobal.__godotMinigamePixelRatio)||window.devicePixelRatio)||1;try{if(typeof wx!=="undefined"){const info=wx.getWindowInfo?wx.getWindowInfo():wx.getSystemInfoSync&&wx.getSystemInfoSync();if(info){ratio=Number(info.pixelRatio||info.devicePixelRatio||ratio)||ratio}}}catch(e){}return Math.max(1,ratio)}`
 }
 // getValue, setValue
 const GET_VALUE_TEMPLATE = {

--- a/skills/scripts/godot_process.js
+++ b/skills/scripts/godot_process.js
@@ -27,6 +27,10 @@ const PERFORMANCE_TIME_TEMPLATE = {
     match: `_emscripten_get_now=()=>performance.now()`,
     replace: `_emscripten_get_now=nowPolyfill`
 }
+const DISPLAY_PIXEL_RATIO_TEMPLATE = {
+    match: `getPixelRatio:function(){return GodotDisplayScreen.hidpi?window.devicePixelRatio||1:1}`,
+    replace: `getPixelRatio:function(){if(!GodotDisplayScreen.hidpi){return 1}let ratio=Number(window.devicePixelRatio)||1;try{if(typeof wx!=="undefined"){const info=wx.getWindowInfo?wx.getWindowInfo():wx.getSystemInfoSync&&wx.getSystemInfoSync();if(info){ratio=Number(info.pixelRatio||info.devicePixelRatio||ratio)||ratio}}}catch(e){}return Math.max(1,ratio)}`
+}
 // getValue, setValue
 const GET_VALUE_TEMPLATE = {
     match: `case"i64":abort("to do getValue(i64) use WASM_BIGINT");`,
@@ -64,6 +68,7 @@ const newGodotJsContent = originGodotJsContent.
 //     .replace(WEB_GL_INSTANCE_TEMPLATE.match, WEB_GL_INSTANCE_TEMPLATE.replace)
     .replace(WEB_TILE_DISABLE_TEMPLATE.match, WEB_TILE_DISABLE_TEMPLATE.replace)
     .replace(PERFORMANCE_TIME_TEMPLATE.match, PERFORMANCE_TIME_TEMPLATE.replace)
+    .replace(DISPLAY_PIXEL_RATIO_TEMPLATE.match, DISPLAY_PIXEL_RATIO_TEMPLATE.replace)
     .replace(GET_VALUE_TEMPLATE.match, GET_VALUE_TEMPLATE.replace)
     .replace(SET_VALUE_TEMPLATE.match, SET_VALUE_TEMPLATE.replace)
     .replace(WX_FS_TEMPLATE.match, WX_FS_TEMPLATE.replace)

--- a/skills/sources/godot-4.6.2-rc-a16e481cf4/godot_process.js
+++ b/skills/sources/godot-4.6.2-rc-a16e481cf4/godot_process.js
@@ -23,6 +23,11 @@ const REPLACE_RULES = [
         replace: `_emscripten_get_now=nowPolyfill`,
     },
     {
+        name: "display-pixel-ratio",
+        match: `getPixelRatio:function(){return GodotDisplayScreen.hidpi?window.devicePixelRatio||1:1}`,
+        replace: `getPixelRatio:function(){if(!GodotDisplayScreen.hidpi){return 1}let ratio=Number(window.devicePixelRatio)||1;try{if(typeof wx!=="undefined"){const info=wx.getWindowInfo?wx.getWindowInfo():wx.getSystemInfoSync&&wx.getSystemInfoSync();if(info){ratio=Number(info.pixelRatio||info.devicePixelRatio||ratio)||ratio}}}catch(e){}return Math.max(1,ratio)}`,
+    },
+    {
         name: "getvalue-i64",
         match: `case"i64":abort("to do getValue(i64) use WASM_BIGINT");`,
         replace: `case"i64":return HEAP32[ptr>>2];`,

--- a/skills/sources/godot-4.6.2-rc-a16e481cf4/godot_process.js
+++ b/skills/sources/godot-4.6.2-rc-a16e481cf4/godot_process.js
@@ -25,7 +25,7 @@ const REPLACE_RULES = [
     {
         name: "display-pixel-ratio",
         match: `getPixelRatio:function(){return GodotDisplayScreen.hidpi?window.devicePixelRatio||1:1}`,
-        replace: `getPixelRatio:function(){if(!GodotDisplayScreen.hidpi){return 1}let ratio=Number(window.devicePixelRatio)||1;try{if(typeof wx!=="undefined"){const info=wx.getWindowInfo?wx.getWindowInfo():wx.getSystemInfoSync&&wx.getSystemInfoSync();if(info){ratio=Number(info.pixelRatio||info.devicePixelRatio||ratio)||ratio}}}catch(e){}return Math.max(1,ratio)}`,
+        replace: `getPixelRatio:function(){if(!GodotDisplayScreen.hidpi){return 1}let ratio=Number((typeof GameGlobal!=="undefined"&&GameGlobal.__godotMinigamePixelRatio)||window.devicePixelRatio)||1;try{if(typeof wx!=="undefined"){const info=wx.getWindowInfo?wx.getWindowInfo():wx.getSystemInfoSync&&wx.getSystemInfoSync();if(info){ratio=Number(info.pixelRatio||info.devicePixelRatio||ratio)||ratio}}}catch(e){}return Math.max(1,ratio)}`,
     },
     {
         name: "getvalue-i64",


### PR DESCRIPTION
## Summary

This collects the runtime fixes verified while testing a Godot 4.5.1 WeChat Mini Game export on DevTools, Android, and iOS high performance mode.

- Fix iOS/high-DPI canvas sharpness by using `wx.getWindowInfo().pixelRatio` with `devicePixelRatio` fallback.
- Patch generated Godot display code to use the same WeChat pixel ratio source.
- Render the loading background with cover behavior instead of stretching it.
- Normalize WeChat subpackage progress whether the runtime reports `0..100` or `0..1`, keep progress monotonic, and repaint on the next animation frame.
- Flush/commit the WebGL loading frame when explicit swap control is available.
- Document the runtime behavior and add iOS high performance DPR validation coverage.

## Root Cause

The smoke test found several runtime differences across WeChat environments:

- iOS high performance mode exposed the useful DPR through `wx.getWindowInfo().pixelRatio`; relying on `devicePixelRatio` alone can leave the canvas backing store at DPR 1 and make the game blurry on high-DPI iPhones.
- Loading backgrounds were stretched to the viewport instead of preserving aspect ratio.
- Subpackage progress callbacks can be observed as either `0..100` or `0..1`, so always dividing by 100 can make progress look stuck near zero.
- The loading screen WebGL context may need an explicit `flush()` / `commit()` after drawing when explicit swap control is used.

## Validation

- `node --check skills/assets/min-runtime/godot-loader.js`
- `node --check skills/scripts/godot_process.js`
- `node --check skills/sources/godot-4.6.2-rc-a16e481cf4/godot_process.js`
- `git diff --check`

## Notes

This PR does not change WebAssembly build flags. In testing, iOS wasm startup also required enabling the WeChat AppID iOS high performance capability in the MP backend; without that capability WeChat can fail before Godot starts with a native `load wasm failed` error.
